### PR TITLE
add backlink support

### DIFF
--- a/.github/workflows/mkdocs_build.yml
+++ b/.github/workflows/mkdocs_build.yml
@@ -36,8 +36,8 @@ jobs:
             yarn run build
       - name: Run Note Link Janitor
         run: ${{ github.workspace }}/note-link-janitor/dist/index.js ${{ github.workspace }}/docs
-#       - name: Remove Janitor folder
-#         run: rm --force -r note-link-janitor
+      - name: Remove Janitor folder
+        run: rm --force -r note-link-janitor
             
       - uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
use janitor to add backlinks to markdown files before running mkdoc. this info is never saved or commited and only used for website build. so notes are never changed.